### PR TITLE
Fix queries

### DIFF
--- a/bafs/views/chartdata.py
+++ b/bafs/views/chartdata.py
@@ -736,20 +736,87 @@ def fmt_if_safe(fmt, val):
         return fmt % val
     return ''
 
-@blueprint.route("/indiv_coldest")
-def indiv_coldest():
-    q = text("""
-            select A.display_name as athlete_name,
-            min(ride_temp_start) as temp_start,
+def coldest_query():
+    return """
+         select A.display_name as athlete_name,
+         A.id as ath_id,
+            W.ride_temp_start as temp_start,
             R.start_date as date,
             R.location as loc,
             R.moving_time as moving
             from rides R
             inner join ride_weather W on R.id=W.ride_id
             inner join athletes A on A.id=R.athlete_id
-            group by athlete_name
-            order by temp_start, moving DESC;
-            """)
+            inner join (
+              select A2.id as ath2_id,
+                  min(ride_temp_start) as temp2
+              from rides R2
+              inner join ride_weather W2 on R2.id=W2.ride_id
+              inner join athletes A2 on A2.id=R2.athlete_id
+              group by A2.id
+             ) as SQ
+           ON SQ.temp2 = W.ride_temp_start
+           AND SQ.ath2_id = A.id
+          group by athlete_name
+          order by temp_start, moving DESC;
+          """;
+
+def snowiest_query():
+    return """
+         select A.display_name as athlete_name,
+         A.id as ath_id,
+            W.ride_precip as snow,
+            R.start_date as date,
+            R.location as loc,
+            R.moving_time as moving
+            from rides R
+            inner join ride_weather W on R.id=W.ride_id
+            inner join athletes A on A.id=R.athlete_id
+            inner join (
+              select A2.id as ath2_id,
+                  max(ride_precip) as snow2
+              from rides R2
+              inner join ride_weather W2 on R2.id=W2.ride_id
+              inner join athletes A2 on A2.id=R2.athlete_id
+              where W2.ride_snow=1
+              group by A2.id
+             ) as SQ
+           ON SQ.snow2 = W.ride_precip
+           AND SQ.ath2_id = A.id
+          group by athlete_name
+          order by snow DESC, moving DESC;
+    """;
+
+def rainiest_query():
+    return """
+         select A.display_name as athlete_name,
+         A.id as ath_id,
+            W.ride_precip as rain,
+            R.start_date as date,
+            R.location as loc,
+            R.moving_time as moving
+            from rides R
+            inner join ride_weather W on R.id=W.ride_id
+            inner join athletes A on A.id=R.athlete_id
+            inner join (
+              select A2.id as ath2_id,
+                  max(ride_precip) as rain2
+              from rides R2
+              inner join ride_weather W2 on R2.id=W2.ride_id
+              inner join athletes A2 on A2.id=R2.athlete_id
+              where W2.ride_rain=1
+              group by A2.id
+             ) as SQ
+           ON SQ.rain2 = W.ride_precip
+           AND SQ.ath2_id = A.id
+          group by athlete_name
+          order by rain DESC, moving DESC;
+    """;
+
+
+@blueprint.route("/indiv_coldest")
+def indiv_coldest():
+    q = text(coldest_query())
     hl=lambda res, ql: "%.2f F for %s on %s in %s" % (
             res['temp_start'],
             fmt_dur(res['moving']),
@@ -759,19 +826,7 @@ def indiv_coldest():
 
 @blueprint.route("/indiv_snowiest")
 def indiv_snowiest():
-    q = text("""
-            select A.display_name as athlete_name,
-            max(ride_precip) as snow,
-            R.moving_time as moving,
-            R.location as loc,
-            R.start_date as date
-            from rides R
-            inner join ride_weather W on R.id=W.ride_id
-            inner join athletes A on A.id=R.athlete_id
-            where W.ride_snow=1
-            group by athlete_name
-            order by snow DESC, moving DESC;
-            """)
+    q = text(snowiest_query())
     hl=lambda res, ql: "%.2f in for %s on %s in %s" % (
             res['snow'],
             fmt_dur(res['moving']),
@@ -781,19 +836,7 @@ def indiv_snowiest():
 
 @blueprint.route("/indiv_rainiest")
 def indiv_rainiest():
-    q = text("""
-            select A.display_name as athlete_name,
-            max(ride_precip) as rain,
-            R.moving_time as moving,
-            R.location as loc,
-            R.start_date as date
-            from rides R
-            inner join ride_weather W on R.id=W.ride_id
-            inner join athletes A on A.id=R.athlete_id
-            where W.ride_rain=1
-            group by athlete_name
-            order by rain DESC, moving DESC;
-            """)
+    q = text(rainiest_query())
     hl=lambda res, ql: "%.2f in for %s on %s in %s" % (
             res['rain'],
             fmt_dur(res['moving']),

--- a/bafs/views/chartdata.py
+++ b/bafs/views/chartdata.py
@@ -724,7 +724,6 @@ def exec_and_jsonify_query(q, display_label, query_label, hover_lambda = lambda 
     return gviz_api_jsonify({'cols': cols, 'rows': rows})
 
 def fmt_date(dt):
-    #dt=datetime.strptime(date_str, '%Y-%m-%d %H:%M:%S')
     return dt.strftime('%Y-%m-%d')
 
 def fmt_dur(elapsed_sec):
@@ -735,7 +734,6 @@ def fmt_if_safe(fmt, val):
     if val:
         return fmt % val
     return ''
-
 
 def parameterized_suffering_query(weath_field,
         weath_nick,
@@ -767,19 +765,11 @@ def parameterized_suffering_query(weath_field,
           order by {1} {3}, moving DESC;
           """.format(weath_field, weath_nick, func, desc, superlative_restriction);
 
-def coldest_query():
-    return parameterized_suffering_query('ride_temp_start', 'temp_start', func='min')
-
-def snowiest_query():
-    return parameterized_suffering_query('ride_precip', 'snow', func='max', desc='desc', superlative_restriction='W2.ride_snow=1')
-
-def rainiest_query():
-    return parameterized_suffering_query('ride_precip', 'rain', func='max', desc='desc', superlative_restriction='W2.ride_rain=1')
-
-
 @blueprint.route("/indiv_coldest")
 def indiv_coldest():
-    q = text(coldest_query())
+    q = text(parameterized_suffering_query('ride_temp_start',
+        'temp_start',
+        func='min'))
     hl=lambda res, ql: "%.2f F for %s on %s in %s" % (
             res['temp_start'],
             fmt_dur(res['moving']),
@@ -789,7 +779,11 @@ def indiv_coldest():
 
 @blueprint.route("/indiv_snowiest")
 def indiv_snowiest():
-    q = text(snowiest_query())
+    q = text(parameterized_suffering_query('ride_precip',
+        'snow',
+        func='max',
+        desc='desc',
+        superlative_restriction='W2.ride_snow=1'))
     hl=lambda res, ql: "%.2f in for %s on %s in %s" % (
             res['snow'],
             fmt_dur(res['moving']),
@@ -799,7 +793,11 @@ def indiv_snowiest():
 
 @blueprint.route("/indiv_rainiest")
 def indiv_rainiest():
-    q = text(rainiest_query())
+    q = text(parameterized_suffering_query('ride_precip',
+        'rain',
+        func='max',
+        desc='desc',
+        superlative_restriction='W2.ride_rain=1'))
     hl=lambda res, ql: "%.2f in for %s on %s in %s" % (
             res['rain'],
             fmt_dur(res['moving']),


### PR DESCRIPTION
The labels for the new charts were incorrect (only min value and athlete name were correct). The ancilary non-min values (like location, date, duration) selected by the previous queries didn't actually grab the values corresponding to the min value.  For example, my personal min temperature of 12.9 was attributed to Jan 4, although that temperature actually occurred on Jan 8.  Now the dates, durations, and locations of the scores shown in the mouse-hover labels are correct.

![jan8-was-cold](https://cloud.githubusercontent.com/assets/275366/5690373/b375ce50-9852-11e4-89e7-8d30dfd432a9.png)

